### PR TITLE
added stdin.end() to fix Windows sync mode bug

### DIFF
--- a/lib/wav-player.js
+++ b/lib/wav-player.js
@@ -63,6 +63,7 @@ WavPlayer.prototype.play = function(params) {
 				'-c',
 				'(New-Object Media.SoundPlayer "' + path + '").PlaySync();'
 			]);
+		this._proc.stdin.end();	
 		} else if(os === 'darwin') {
 			this._proc = mSpawn('afplay', [path]);
 		} else if(os === 'linux') {


### PR DESCRIPTION
Please see https://github.com/futomi/node-wav-player/issues/1