### PR TITLE
Added error catching to spawn child process

### DIFF
--- a/lib/wav-player.js
+++ b/lib/wav-player.js
@@ -112,6 +112,10 @@ WavPlayer.prototype._play = function (params) {
 				resolve();
 			}, 500);
 		}
+		
+		this._proc.on('error', function(err) {
+			reject(new Error('Failed to play the wav file (' + err + ')'));
+		});
 
 		this._proc.on('close', (code) => {
 			if (timer) {


### PR DESCRIPTION
If you run this package on a system that does not have a valid audio player installed and attempt to play a file, you get an uncaught error. This minor change catches that error and handles it properly allowing the project calling this module to handle the error gracefully instead of terminating.